### PR TITLE
Correção para funcionar com o angular 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pluralizador",
   "version": "1.0.1",
   "description": "Pluralizador de substantivos.",
-  "main": "./index.js",
+  "main": "./src/index.js",
   "scripts": {
     "test": "mocha"
   },

--- a/src/pluralizer.js
+++ b/src/pluralizer.js
@@ -1,7 +1,7 @@
 module.exports = class Pluralizer {
 
   constructor() {
-    rules = []
+    this.rules = []
   }
 
   addRule(rule) {

--- a/src/pluralizer.js
+++ b/src/pluralizer.js
@@ -1,5 +1,8 @@
 module.exports = class Pluralizer {
-  rules = []
+
+  constructor() {
+    rules = []
+  }
 
   addRule(rule) {
     this.rules.push(rule)


### PR DESCRIPTION
Utilizo a biblioteca em um projeto Angular, ao atualizar para versão 11 do Angular obtive os seguintes erros:

![image](https://user-images.githubusercontent.com/12162945/108802163-61109700-7576-11eb-8c8c-916dc309437c.png)
Ao informar o path do index.js corretamente o erro foi corrigido.

![image](https://user-images.githubusercontent.com/12162945/108802015-fd866980-7575-11eb-9859-fdecac69555c.png)
Ao instanciar `rules` no `constructor()` o erro foi corrigido.

